### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -280,6 +280,7 @@ a {
   background-color: #FFF;
   color: black;
   padding: 1vw;
+  
 }
 
 .item-name {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
 before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/items/_items.html.erb
+++ b/app/views/items/_items.html.erb
@@ -1,0 +1,27 @@
+<li class='list'>
+  <%= link_to "#" do %>
+    <div class='item-img-content'>
+      <%= image_tag item.image, class: "item-img" %>
+
+      <%# 商品購入機能実装後にsold outの表示をさせる %>
+      <%# <% if item.order %> %>
+        <%# <div class='sold-out'> %> %>
+          <%# <span>Sold Out!!</span> %> %>
+        <%# </div> %> %>
+      <%# <% end %> %>
+
+    </div>
+    <div class='item-info'>
+      <h3 class='item-name'>
+        <%= item.name %>
+      </h3>
+      <div class='item-price'>
+        <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
+        <div class='star-btn'>
+          <%= image_tag "star.png", class:"star-icon" %>
+          <span class='star-count'>0</span>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</li>

--- a/app/views/items/_items.html.erb
+++ b/app/views/items/_items.html.erb
@@ -4,11 +4,11 @@
       <%= image_tag item.image, class: "item-img" %>
 
       <%# 商品購入機能実装後にsold outの表示をさせる %>
-      <%# <% if item.order %> %>
-        <%# <div class='sold-out'> %> %>
-          <%# <span>Sold Out!!</span> %> %>
-        <%# </div> %> %>
-      <%# <% end %> %>
+      <%# if item.order %>
+        <%# <div class='sold-out'> %>
+          <%# <span>Sold Out!!</span>  %>
+        <%# </div> %>
+      <%# <% end %>
 
     </div>
     <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,60 +124,9 @@
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-    <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
-    </ul>
-  </div>
+    <ul  l class='item-lists'>
+      <%= render partial: 'items', collection: @items, as: 'item' %>
+    </ul>  
   <%# /商品一覧 %>
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,8 +126,32 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul  l class='item-lists'>
       <%= render partial: 'items', collection: @items, as: 'item' %>
+
+      <%# 商品がない場合のダミー %>
+      <% if @items.blank? %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+      <%# /商品がない場合のダミー %>
+
     </ul>  
   <%# /商品一覧 %>
+
 </div>
 
 <%= link_to(new_item_path, class: 'purchase-btn') do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,6 +129,7 @@
     </ul>  
   <%# /商品一覧 %>
 </div>
+
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>


### PR DESCRIPTION
# what
出品済商品一覧をトップページに表示させる機能


# why
出品済商品を一覧で確認できるようにするため


# 機能の様子
・ログイン状態のユーザーが商品一覧ページを見ることができる
https://gyazo.com/b3450552df71942081690f0670ae6d9c

・ログアウト状態のユーザーが商品一覧ページを見ることができる
https://gyazo.com/c52d4d1238345c1e702f7d859f3971d4

・出品済商品は、上から日時が新しい順に表示される
https://gyazo.com/d9c8107deef46ba40182148198671b92

